### PR TITLE
Add support for ActiveRecord 5.0 and 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,25 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
-  - 2.2.3
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - AR=3.2.18
-    - AR=4.0.5
-    - AR=4.1.1
-    - AR=4.2.5
+    - AR=3.2.22.5
+    - AR=4.0.13
+    - AR=4.1.16
+    - AR=4.2.8
+matrix:
+  exclude:
+    - rvm: 2.4.1
+      env: AR=3.2.22.5
+    - rvm: 2.4.1
+      env: AR=4.0.13
+    - rvm: 2.4.1
+      env: AR=4.1.16
 before_script:
   - mysql -e 'create database seeder_test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,22 @@ env:
     - AR=4.0.13
     - AR=4.1.16
     - AR=4.2.8
+    - AR=5.0.3
+    - AR=5.1.1
 matrix:
   exclude:
+    - rvm: 1.9.3
+      env: AR=5.0.3
+    - rvm: 1.9.3
+      env: AR=5.1.1
+    - rvm: 2.0.0
+      env: AR=5.0.3
+    - rvm: 2.0.0
+      env: AR=5.1.1
+    - rvm: 2.1.10
+      env: AR=5.0.3
+    - rvm: 2.1.10
+      env: AR=5.1.1
     - rvm: 2.4.1
       env: AR=3.2.22.5
     - rvm: 2.4.1

--- a/seeder.gemspec
+++ b/seeder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   s.license = 'MIT'
 
-  s.add_dependency('activerecord', '>= 3.2', '< 5.0')
+  s.add_dependency('activerecord', '>= 3.2', '< 5.2')
 
   s.add_development_dependency('mysql2', '~> 0.3.10')
   s.add_development_dependency('rspec', '~> 3.0')

--- a/seeder.gemspec
+++ b/seeder.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 3.2', '< 5.0')
 
   s.add_development_dependency('mysql2', '~> 0.3.10')
-  s.add_development_dependency('rspec-rails', '~> 3.0')
+  s.add_development_dependency('rspec', '~> 3.0')
+  s.add_development_dependency('rake', '>= 10.4')
 end

--- a/spec/seeder_spec.rb
+++ b/spec/seeder_spec.rb
@@ -76,10 +76,12 @@ describe Seeder do
     end
 
     it 'aborts when an exception is raised' do
-      expect(seeder).to receive(:create_new_records).and_raise
+      allow(seeder)
+        .to receive(:create_new_records)
+        .and_raise(ActiveRecord::RecordInvalid.new(Grade.new))
       initial_attributes = Grade.all.map(&:attributes)
 
-      expect { seeder.create }.to raise_error
+      expect { seeder.create }.to raise_error(ActiveRecord::RecordInvalid)
 
       expect(Grade.all.map(&:attributes)).to eq(initial_attributes)
     end

--- a/spec/seeder_spec.rb
+++ b/spec/seeder_spec.rb
@@ -93,7 +93,7 @@ describe Seeder do
       seeder.create
 
       expect(Grade.count).to eq(2)
-      expect(Grade.exists?(grade1)).to eq(false)
+      expect(Grade.exists?(grade1.id)).to eq(false)
 
       grade2.reload
       expect(grade2.student_id).to eq(1)

--- a/spec/support/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/spec/support/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1,0 +1,9 @@
+# Patch support for MySQL 5.7+ onto ActiveRecord < 4.1.
+if ActiveRecord::VERSION::MAJOR < 4 ||
+   (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR < 1)
+
+  require 'active_record/connection_adapters/abstract_mysql_adapter'
+  class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
+    NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+  end
+end

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -1,3 +1,5 @@
+require 'support/active_record/connection_adapters/abstract_mysql_adapter'
+
 ActiveRecord::Base.establish_connection({
   adapter: 'mysql2',
   username: 'travis',

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -6,7 +6,9 @@ ActiveRecord::Base.establish_connection({
   database: 'seeder_test'
 })
 
-ActiveRecord::Base.connection.tables.each do |table|
+tables_method = ActiveRecord::VERSION::MAJOR >= 5 ? :data_sources : :tables
+
+ActiveRecord::Base.connection.public_send(tables_method).each do |table|
   ActiveRecord::Base.connection.drop_table table
 end
 


### PR DESCRIPTION
This PR updates seeder to support ActiveRecord 5.0 and 5.1. Very few changes were required to get everything working on the new versions, so most of the comments here only needed to address deprecations and update specs.