### PR TITLE
Add support for ActiveRecord 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.10
   - 2.2.7
@@ -12,18 +11,11 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - AR=3.2.22.5
-    - AR=4.0.13
-    - AR=4.1.16
-    - AR=4.2.8
     - AR=5.0.3
     - AR=5.1.1
+    - AR=5.2.2
 matrix:
   exclude:
-    - rvm: 1.9.3
-      env: AR=5.0.3
-    - rvm: 1.9.3
-      env: AR=5.1.1
     - rvm: 2.0.0
       env: AR=5.0.3
     - rvm: 2.0.0
@@ -32,11 +24,5 @@ matrix:
       env: AR=5.0.3
     - rvm: 2.1.10
       env: AR=5.1.1
-    - rvm: 2.4.1
-      env: AR=3.2.22.5
-    - rvm: 2.4.1
-      env: AR=4.0.13
-    - rvm: 2.4.1
-      env: AR=4.1.16
 before_script:
   - mysql -e 'create database seeder_test;'

--- a/lib/seeder/version.rb
+++ b/lib/seeder/version.rb
@@ -1,3 +1,3 @@
 class Seeder
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/seeder.gemspec
+++ b/seeder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   s.license = 'MIT'
 
-  s.add_dependency('activerecord', '>= 3.2', '< 5.2')
+  s.add_dependency('activerecord', '>= 3.2', '<= 6.0')
 
   s.add_development_dependency('mysql2', '~> 0.3.10')
   s.add_development_dependency('rspec', '~> 3.0')

--- a/seeder.gemspec
+++ b/seeder.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "LICENSE.txt"]
   s.license = 'MIT'
 
-  s.add_dependency('activerecord', '>= 3.2', '<= 6.0')
+  s.add_dependency('activerecord', '>= 5.0', '<= 6.0')
 
-  s.add_development_dependency('mysql2', '~> 0.3.10')
+  s.add_development_dependency('mysql2', '>= 0.4.4', '< 0.6.0')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rake', '>= 10.4')
 end


### PR DESCRIPTION
This PR adds support for ActiveRecord 5.2, and removes unsupported versions from the build matrix.